### PR TITLE
Update woocommerce-extension-boilerplate-lite.php

### DIFF
--- a/woocommerce-extension-boilerplate-lite/woocommerce-extension-boilerplate-lite.php
+++ b/woocommerce-extension-boilerplate-lite/woocommerce-extension-boilerplate-lite.php
@@ -361,7 +361,7 @@ final class WC_Extend_Plugin_Name {
 			$this->ajax_includes();
 		}
 
-		if ( ! is_admin() || defined('DOING_AJAX') ) {
+		if ( ! is_admin() || !defined('DOING_AJAX') ) {
 			$this->frontend_includes();
 		}
 
@@ -379,7 +379,8 @@ final class WC_Extend_Plugin_Name {
 		if( version_compare(WC_EXTEND_WOOVERSION, '1.6.6', '>' ) ) {
 			// Include the settings page to add our own settings.
 			include_once( $this->wc_plugin_path() . 'includes/admin/settings/class-wc-settings-page.php' );
-			$this->wc_settings_page = new WC_Settings_Page(); // Call the settings page for WooCommerce.
+			include_once( 'includes/admin/class-wc-extension-plugin-name-admin-settings.php' );
+			$this->wc_settings_page = new WC_Extend_Plugin_Name_Admin_Settings(); // Call the settings page for WooCommerce.
 		}
 
 		include_once( 'includes/wc-extension-plugin-name-hooks.php' ); // Hooks used in the admin

--- a/woocommerce-extension-boilerplate-lite/woocommerce-extension-boilerplate-lite.php
+++ b/woocommerce-extension-boilerplate-lite/woocommerce-extension-boilerplate-lite.php
@@ -361,7 +361,7 @@ final class WC_Extend_Plugin_Name {
 			$this->ajax_includes();
 		}
 
-		if ( ! is_admin() || !defined('DOING_AJAX') ) {
+		if ( ! is_admin() || defined('DOING_AJAX') ) {
 			$this->frontend_includes();
 		}
 


### PR DESCRIPTION
Fixes fatal error on line 382 as the WooCommerce::WC_Settings_Page class is now abstract in latest WooCommerce version.
